### PR TITLE
Resolving firing instability

### DIFF
--- a/Assets/Controllers/Player.cs
+++ b/Assets/Controllers/Player.cs
@@ -31,13 +31,12 @@ public class Player : MonoBehaviour {
 	
 	// Update is called once per frame
 	void Update () {
-		
+        Fire();
 	}
 
 	void FixedUpdate () {
 		Rotate ();
 		Move ();
-		Fire ();
 	}
 
 	void Rotate () {

--- a/Assets/Entities/Entity.cs
+++ b/Assets/Entities/Entity.cs
@@ -18,7 +18,6 @@ public abstract class Entity : Actuator {
 		base.Start();
 		defunct = false;
 
-		//TODO: do not sure healthbar for low hp projectile
         if (displayHP)
         {
             healthBarContainerGameObject = (GameObject)Instantiate(HUDManager.hUDManager.healthBarContainerStock, new Vector2(transform.position.x, transform.position.y + 0.6f), Quaternion.identity);


### PR DESCRIPTION
I moved the Fire() method into Update() rather than FixedUpdate(). I believe this will resolve the issue because Input.GetMouseButtonDown() appears to only return true if the mouse button is down during that exact frame. Because fixedupdate, I suspect, is not run in sync with frames, this is probably what is causing the issue with firing instability.
